### PR TITLE
creates a userContext, this will set a single currentUser profile as …

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import AuthContextProvider from './contexts/AuthContext'
+import UserContextProvider from './contexts/UserContext';
+import UsersContextProvider from './contexts/UsersContext';
 import { Switch, Route } from "react-router-dom";
 import { LandingPage } from 'components/LandingPage/LandingPage';
 import LogInPage from 'components/LogIn';
@@ -16,15 +18,13 @@ import UIKit from 'components/UIKit'
 import NavBar from 'uiKit/navbars/AppNav';
 import { Footer } from 'uiKit/Footer';
 import UploadFileWrapper from './components/DocumentsUpload/UploadFileWrapper';
-// import contexts here
-// import { ExampleContext } from 'src/contexts/ExampleContext';
-import UsersContextProvider from './contexts/UsersContext';
 
 const App = () => {
   return (
     // wrapping components in custom MuiThemeProvider to match Hatchstone style guide
     <MuiThemeProvider theme={theme}>
       <AuthContextProvider>
+        <UserContextProvider>
         <NavBar />
           <Switch>
             <Route path='/ui-kit'>
@@ -47,6 +47,7 @@ const App = () => {
             </UsersContextProvider>
           </Switch>
         <Footer />
+        </UserContextProvider>
       </AuthContextProvider>
     </MuiThemeProvider>
   );

--- a/src/components/Conversations/index.jsx
+++ b/src/components/Conversations/index.jsx
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import styled from 'styled-components';
 import ConversationsTable from './ConversationsTable';
 import MessagesTable from './MessagesTable';
+import { UserContext } from '../../contexts/UserContext';
+import { AuthContext } from '../../contexts/AuthContext';
 
 // fix this
 const Wrapper = styled.div`
@@ -9,10 +11,14 @@ const Wrapper = styled.div`
 `
 
 const ConversationsPage = () => {
-    // TODO - consume context here
+    // remove below, for testing UserContext only
+    const { currentUserProfile } = useContext(UserContext);
 
+    console.log('in convo page render');
     return (
         <Wrapper>
+            {/* remove below, for testing UserContext only */}
+            {Object.keys(currentUserProfile).length ? currentUserProfile.userId.email : 'false'}
             <ConversationsTable />
             <MessagesTable />
         </Wrapper>

--- a/src/components/LogIn/index.jsx
+++ b/src/components/LogIn/index.jsx
@@ -56,7 +56,7 @@ const ValidationSchema = Yup.object().shape({
     .required("This field is required")
     .matches(
       /^(?=.{8,})(?=.*[1-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[(!@#$%^&*()_+|~\- =\`{}[\]:”;'<>?,.\/, )])(?!.*(.)\1{2,}).+$/,
-      "Must contain 8 Characters, minimum 1 Number and 1 Special Case Character"
+      "Must contain 8 Characters, minimum 1 Number, 1 Special Case Character, 1 Uppercase Character"
     )
 })
 

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -11,9 +11,10 @@ const AuthContextProvider = ({ children }) => {
 
   useEffect(() => {
     const user = JSON.parse(localStorage.getItem('currentUser'));
-    console.log(`current user's profile: \n`, currentUserProfile)
+    // console.log(`current user's profile: \n`, currentUserProfile)
     console.log(`currentUser: \n`, user)
-  })
+    setCurrentUser(user);
+  }, [])
 
   const loginUser = async (email, password) => {
     console.log(`in AuthContext loginUser function`)

--- a/src/contexts/UserContext.jsx
+++ b/src/contexts/UserContext.jsx
@@ -1,0 +1,49 @@
+import React, { Component, createContext, useState, useContext, useEffect } from 'react';
+import { AuthContext } from './AuthContext';
+import axios from '../config/axiosConfig';
+
+export const UserContext = createContext({});
+
+const UserContextProvider = ({ children }) => {
+    const { currentUser } = useContext(AuthContext);
+    const [currentUserProfile, setCurrentUserProfile] = useState({});
+    
+    // we can not do an async call directly in useEffect so we need a function
+    const getProfile = async (userId) => {
+        try {
+            console.log('in get profile');
+            const result = await axios.get(`profiles/findByUser/${userId}`);
+            console.log(result.data[0]);
+                if(result.data) {
+                    setCurrentUserProfile(result.data[0])
+                }
+        } catch(err) {
+            console.log(err);
+        }
+    }
+
+    // userId will be undefined first time, handle this and monitor for change in currentUser
+    useEffect(() => {
+        console.log('in useEffect - UserContext');
+        console.log(currentUser._id);
+        const userId = currentUser._id; 
+        if(userId) {
+            getProfile(userId);
+        }
+        console.log(`currentUserProfile \n`, currentUserProfile);
+    }, [currentUser])
+
+    
+    return (
+        <UserContext.Provider value={{
+                currentUserProfile: currentUserProfile
+        }}>
+            {children}
+        </UserContext.Provider>
+    )
+
+}
+
+
+
+export default UserContextProvider


### PR DESCRIPTION
--Context to provide the profile of the currentUser app wide--

-After login AuthContext will set the currentUser
-CurrentUser is consumed by UserContext (singular)
-The db is queried to retrieve the Profile matching the currentUser userId and setCurrentUserProfile is called,
-the new currentUserProfile state can now  be consumed down the component tree

-@chrisstaudinger this means that you can remove 
const [ currentUserProfile, setCurrentUserProfile ] = useState({})
from Auth context and any components using these states and replace with UserContext to be consistent and for better separation of concerns